### PR TITLE
Handles the case of supervisor web interface not requiring authentication

### DIFF
--- a/application/views/welcome.php
+++ b/application/views/welcome.php
@@ -65,7 +65,12 @@ $muted = (isset($_COOKIE['mute'])?$_COOKIE['mute']:0);
 				$alert = false;
 				foreach($list as $name=>$procs){
 					$parsed_url = parse_url($cfg[$name]['url']);
-					$ui_url = 'http://' . $cfg[$name]['username'] . ':' . $cfg[$name]['password'] . '@' . $parsed_url['host'] . ':' . $cfg[$name]['port']. '/';
+                    if ( isset($cfg[$name]['username']) && isset($cfg[$name]['password']) ){
+                        $base_url = 'http://' . $cfg[$name]['username'] . ':' . $cfg[$name]['password'] . '@';
+                    }else{
+                        $base_url = 'http://';
+                    }
+                    $ui_url = $base_url . $parsed_url['host'] . ':' . $cfg[$name]['port']. '/';
 				?>
 				<div class="span4">
 				<table class="table table-bordered table-condensed table-striped">


### PR DESCRIPTION
Hi, we run our supervisors on a closed network and hence do not require authentication. This is supported (although possibly not advised) by supervisord, so I added this check to see if the config for the server in question has a username set in supervisor.conf.
