### PR TITLE
Allow 'EXITED' processes to be launched

### DIFF
--- a/application/views/welcome.php
+++ b/application/views/welcome.php
@@ -132,7 +132,7 @@ $muted = (isset($_COOKIE['mute'])?$_COOKIE['mute']:0);
 								</div//-->
 								<?php if($status=='RUNNING'){ ?>
 								<a href="/control/stop/<?php echo $name.'/'.$item_name;?>" class="btn btn-mini btn-inverse" type="button"><i class="icon-stop icon-white"></i></a>
-								<?php } if($status=='STOPPED'){ ?>
+								<?php } if($status=='STOPPED' || $status == 'EXITED'){ ?>
 								<a href="/control/start/<?php echo $name.'/'.$item_name;?>" class="btn btn-mini btn-success" type="button"><i class="icon-play icon-white"></i></a>
 								<?php } ?>
 							</td>


### PR DESCRIPTION
When processes don't have "autorestart" set to true, they're status become "EXITED", and there's no way to restart them.

With this fix, EXITED processes can be started again.