### PR TITLE
JS refresh fix

### DIFF
--- a/application/views/welcome.php
+++ b/application/views/welcome.php
@@ -193,7 +193,9 @@
 	var $refresh = <?php echo $this->config->item('refresh');?>;
 	var $timer = false;
 	$(window).load(function() {
-		startTimer();
+		if($refresh > 0) {
+			startTimer();
+		}
   	});
 	function stopTimer(){
 		$('#refresh').html('(p)');


### PR DESCRIPTION
//Refresh Dashboard every x seconds. 0 to disable
$config['refresh'] = 10;

Not work. If $config['refresh'] is 0, then startTimer() started...

Now not started startTimer().